### PR TITLE
docs(readme): add the generated repository-layout tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,32 @@ BibTex Citation
 }
 ```
 
+## Repository layout
+
+<!-- BEGIN GENERATED: layout -->
+
+```
+fastRhockey-data/
+├── nhl/
+│   ├── json/
+│   ├── pbp/
+│   ├── player_box/
+│   ├── rosters/
+│   ├── schedules/
+│   └── team_box/
+├── phf/
+│   ├── json/
+│   ├── pbp/
+│   ├── player_box/
+│   ├── rosters/
+│   ├── schedules/
+│   └── team_box/
+└── themes/   # plot themes
+    └── phf_logos/
+```
+
+<!-- END GENERATED: layout -->
+
 ## Reports & explainers
 
 <!-- BEGIN GENERATED: reports -->


### PR DESCRIPTION
Adds the `## Repository layout` section, generated by `sdv-toolkit/tools/render_readme_layout.py` between BEGIN/END markers. Two-level tree: code directories list their numbered stage files, data directories list only child directories. Part of the fleet-wide rollout standardizing three competing shapes onto one.

## Summary by Sourcery

Documentation:
- Add a generated Repository layout section to the README showing the repository’s top-level data and theme directories.